### PR TITLE
Bugfix for using framework with cocoapods

### DIFF
--- a/Source/NSTimeZone+abtz_location.m
+++ b/Source/NSTimeZone+abtz_location.m
@@ -42,7 +42,12 @@ const char *countryCodeAssociatedObjectKey = "abtz_countryCode";
         // zone.tab is available locally if you prefer, but "backward" (used below) is not.
         //NSURL *zonetabURL = [NSURL fileURLWithPath:@"/usr/share/zoneinfo/zone.tab"];
         NSURL *zonetabURL = [[NSBundle mainBundle] URLForResource:@"zone" withExtension:@"tab"];
-        
+
+        // Bugfix for using cocoapods with framework
+        if (!zonetabURL) {
+            zonetabURL = [[NSBundle bundleWithIdentifier:@"org.cocoapods.TZLocation"] URLForResource:@"zone" withExtension:@"tab"];
+        }
+
         NSError *error = nil;
         NSString *zonetabContents = [NSString stringWithContentsOfURL:zonetabURL encoding:NSUTF8StringEncoding error:&error];
         
@@ -59,6 +64,12 @@ const char *countryCodeAssociatedObjectKey = "abtz_countryCode";
         if (matchingLine == nil) {
             // Oh damn, self is using an older zone name. Get the backward compatibility file.
             NSURL *backwardURL = [[NSBundle mainBundle] URLForResource:@"backward" withExtension:nil];
+
+            // Bugfix for using cocoapods with framework
+            if (!backwardURL) {
+                backwardURL = [[NSBundle bundleWithIdentifier:@"org.cocoapods.TZLocation"] URLForResource:@"backward" withExtension:nil];
+            }
+
             NSError *error = nil;
             NSString *backwardContents = [NSString stringWithContentsOfURL:backwardURL encoding:NSUTF8StringEncoding error:&error];
             __block NSString *backwardLine = nil;

--- a/Source/NSTimeZone+abtz_location.m
+++ b/Source/NSTimeZone+abtz_location.m
@@ -37,8 +37,6 @@ const char *countryCodeAssociatedObjectKey = "abtz_countryCode";
 {
     CLLocation *location = objc_getAssociatedObject(self, locationAssociatedObjectKey);
     if (location == nil) {
-        NSLog(@"Getting location for %@", self);
-
         // zone.tab is available locally if you prefer, but "backward" (used below) is not.
         //NSURL *zonetabURL = [NSURL fileURLWithPath:@"/usr/share/zoneinfo/zone.tab"];
         NSURL *zonetabURL = [[NSBundle mainBundle] URLForResource:@"zone" withExtension:@"tab"];
@@ -50,7 +48,7 @@ const char *countryCodeAssociatedObjectKey = "abtz_countryCode";
 
         NSError *error = nil;
         NSString *zonetabContents = [NSString stringWithContentsOfURL:zonetabURL encoding:NSUTF8StringEncoding error:&error];
-        
+
         // Find the line that contains self's timezone name
         __block NSString *matchingLine = nil;
         __block NSString *tzName = [self name];
@@ -60,7 +58,7 @@ const char *countryCodeAssociatedObjectKey = "abtz_countryCode";
                 *stop = YES;
             }
         }];
-        
+
         if (matchingLine == nil) {
             // Oh damn, self is using an older zone name. Get the backward compatibility file.
             NSURL *backwardURL = [[NSBundle mainBundle] URLForResource:@"backward" withExtension:nil];
@@ -104,7 +102,7 @@ const char *countryCodeAssociatedObjectKey = "abtz_countryCode";
                 locationString = matchingLineElements[1];
             }
         }
-        
+
         if (countryCodeString != nil) {
             objc_setAssociatedObject(self, countryCodeAssociatedObjectKey, countryCodeString, OBJC_ASSOCIATION_RETAIN);
         }
@@ -162,7 +160,7 @@ const char *countryCodeAssociatedObjectKey = "abtz_countryCode";
             degrees += [[latLongString substringWithRange:NSMakeRange(6, 2)] doubleValue] / 3600.0;
             break;
         }
-            
+
         default:
             break;
     }

--- a/TZLocation.podspec.json
+++ b/TZLocation.podspec.json
@@ -1,0 +1,29 @@
+{
+  "name": "TZLocation",
+  "version": "0.0.1",
+  "summary": "Probably Approximately Correct Location via Time Zone",
+  "description": "\t\t\tThis project demonstrates how to get a rough approximation of an iOS or Mac OS X device's location using only data stored on the device. No GPS or internet lookups are involved. The resulting data is only approximately accurate, but probably good enough to determine the country or continent where the device is located.\n",
+  "homepage": "https://github.com/atomicbird/TZLocation",
+  "license": {
+    "type": "MIT",
+    "text": "The MIT License (MIT)\n\nCopyright (c) 2013 Tom Harrington \n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.\n"
+  },
+  "authors": {
+    "Tom Harrington": "@atomicbird"
+  },
+  "social_media_url": "http://twitter.com/atomicbird",
+  "platforms": {
+    "ios": "5.0",
+    "osx": "10.7"
+  },
+  "source": {
+    "git": "https://github.com/BenjaminDigeon/TZLocation.git",
+    "commit": "b1d1bbcf7166f6a4f816ef5857501787357c946d"
+  },
+  "source_files": "Source/*{h,m}",
+  "resources": [
+    "Source/backward",
+    "Source/zone.tab"
+  ],
+  "requires_arc": true
+}


### PR DESCRIPTION
When using the cocoapods version of TZLocation with framework option it does not work.

It's cause by : 

``` objc
NSURL *zonetabURL = [[NSBundle mainBundle] URLForResource:@"zone" withExtension:@"tab"];
```

 Who does not work because it use the `mainBundle` the solution should be using 

``` objc
[NSBundle bundleForClass:[self class]]
```

But as TZLocation is a Category of NSTimeZone at Runtime the bundle is `CoreFoundation.framework` 

So i fix it using the cocoapods Bundle identifier (`org.cocoapods.TZLocation`) if the URL is not find with `mainBundle`

I see a more permanent and more complicated solution here : http://lists.apple.com/archives/cocoa-dev/2012/Jul/msg00479.html
